### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/osrf-ros-foxy-desktop.yml
+++ b/.github/workflows/osrf-ros-foxy-desktop.yml
@@ -1,0 +1,31 @@
+name: osrf-ros-foxy-desktop
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    container: osrf/ros:foxy-desktop
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Run rosdep install
+        run: |
+          rosdep update
+          rosdep install -y --from-paths . --ignore-src --rosdistro foxy
+
+      - name: Build
+        run: |
+          . /opt/ros/foxy/setup.sh
+          colcon build --event-handlers console_cohesion+ \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+      - name: Run tests
+        run: |
+          . /opt/ros/foxy/setup.sh
+          colcon test \
+           --event-handlers console_cohesion+ \
+           --return-code-on-test-failure

--- a/.github/workflows/ros-foxy.yml
+++ b/.github/workflows/ros-foxy.yml
@@ -1,0 +1,31 @@
+name: ros-foxy
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    container: ros:foxy
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Run rosdep install
+        run: |
+          rosdep update
+          rosdep install -y --from-paths . --ignore-src --rosdistro foxy
+
+      - name: Build
+        run: |
+          . /opt/ros/foxy/setup.sh
+          colcon build --event-handlers console_cohesion+ \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+      - name: Run tests
+        run: |
+          . /opt/ros/foxy/setup.sh
+          colcon test \
+           --event-handlers console_cohesion+ \
+           --return-code-on-test-failure

--- a/.github/workflows/setup-ros.yml
+++ b/.github/workflows/setup-ros.yml
@@ -1,0 +1,35 @@
+name: setup-ros
+
+on:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@v0.1
+        with:
+          required-ros-distributions: foxy
+
+      - name: Run rosdep install
+        run: |
+          rosdep update
+          rosdep install -y --from-paths . --ignore-src --rosdistro foxy
+
+      - name: Build
+        run: |
+          . /opt/ros/foxy/setup.sh
+          colcon build --event-handlers console_cohesion+ \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+      - name: Run tests
+        run: |
+          . /opt/ros/foxy/setup.sh
+          colcon test \
+           --event-handlers console_cohesion+ \
+           --return-code-on-test-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# colcon
+build/
+install/
+log/
+
+# VSCode
+.vscode

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.5)
+project(test_package)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+# uncomment the following section in order to fill in
+# further dependencies manually.
+# find_package(<dependency> REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/test_package/package.xml
+++ b/test_package/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>test_package</name>
+  <version>0.0.0</version>
+  <description>test package</description>
+  <maintainer email="kenji.miyake@tier4.jp">kenji</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/test_package/test.py
+++ b/test_package/test.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Kenji Miyake
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import os
+
+sys
+os


### PR DESCRIPTION
- Add a test file that causes `wrong import order`

```
./test.py:2:1: I100 Import statements are in the wrong order. 'import os' should be before 'import sys'
import os
^

1     I100 Import statements are in the wrong order. 'import os' should be before 'import sys'
```

- Add 3 types of CI
  - osrf-ros-foxy
  - ros-foxy
  - setup-ros